### PR TITLE
add -x (exclude) option to exclude vm's when using the -a option

### DIFF
--- a/HyperVBackup.Console/Program.cs
+++ b/HyperVBackup.Console/Program.cs
@@ -38,11 +38,14 @@ namespace HyperVBackup.Console
 
         class Options
         {
-            [Option('f', "file", HelpText = "Text file containing a list of VMs to backup, one per line.", MutuallyExclusiveSet = "fla")]
+            [Option('f', "file", HelpText = "Text file containing a list of VMs to backup, one per line.", MutuallyExclusiveSet = "flax")]
             public string File { get; set; }
 
-            [OptionList('l', "list", Separator = ',', HelpText = "List of VMs to backup, comma separated.", MutuallyExclusiveSet = "fla")]
+            [OptionList('l', "list", Separator = ',', HelpText = "List of VMs to backup, comma separated.", MutuallyExclusiveSet = "flax")]
             public IList<string> List { get; set; }
+
+            [OptionList('x', "exclude", Separator = ',', HelpText = "List of VMs to exclude from backup, comma seperated.", MutuallyExclusiveSet = "flx")]
+            public IList<string> Exclude { get; set; }
 
             [OptionList('v', "vhdinclude", Separator = ',', HelpText = "List of VHDs file names to backup, comma separated.")]
             public IList<string> VhdInclude { get; set; }
@@ -185,7 +188,8 @@ namespace HyperVBackup.Console
                         Password = options.Password,
                         ZipFormat = options.ZipFormat,
                         DirectCopy = options.DirectCopy,
-                        MultiThreaded = options.MultiThreaded
+                        MultiThreaded = options.MultiThreaded,
+                        Exclude = options.Exclude
                     };
 
                     var vmNamesMap = mgr.VssBackup(vmNames, nameType, backupOptions, _logger);

--- a/HyperVBackup.Engine/BackupManager.cs
+++ b/HyperVBackup.Engine/BackupManager.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management;
@@ -41,7 +42,7 @@ namespace HyperVBackUp.Engine
             ILogger logger)
         {
             _cancel = false;
-            var vmNamesMap = GetVMNames(vmNames, nameType);
+            var vmNamesMap = GetVMNames(vmNames, options.Exclude, nameType);
 
             if (vmNamesMap.Count > 0)
             {
@@ -588,7 +589,7 @@ namespace HyperVBackUp.Engine
             return (string.Format(scopeFormatStr, host));
         }
 
-        IDictionary<string, string> GetVMNames(IEnumerable<string> vmNames, VmNameType nameType)
+        IDictionary<string, string> GetVMNames(IEnumerable<string> vmNames, IList<string> vmExclude, VmNameType nameType)
         {
             IDictionary<string, string> d = new Dictionary<string, string>();
 
@@ -619,7 +620,12 @@ namespace HyperVBackUp.Engine
                 using (var moc = searcher.Get())
                     foreach (var mo in moc)
                         using (mo)
-                            d.Add((string)mo[vmIdField], (string)mo["ElementName"]);
+                        {
+                            if (vmExclude==null || !vmExclude.Contains((string) mo["ElementName"], StringComparer.Create(CultureInfo.InvariantCulture, true)))
+                            {
+                                d.Add((string) mo[vmIdField], (string) mo["ElementName"]);
+                            }
+                        }
             }
 
             return d;

--- a/HyperVBackup.Engine/Options.cs
+++ b/HyperVBackup.Engine/Options.cs
@@ -10,6 +10,7 @@ namespace HyperVBackUp.Engine
         public string OutputFormat { get; set; }
         public IList<string> VhdInclude { get; set; }
         public IList<string> VhdIgnore { get; set; }
+        public IList<string> Exclude { get; set; }
         public int CompressionLevel { get; set; }
         public bool ZipFormat { get; set; }
         public bool DirectCopy { get; set; }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You can see all options executing the program without arguments, currently those
 ```
 f, file              Text file containing a list of VMs to backup, one per line.
 l, list              List of VMs to backup, comma separated.
+x, exclude           List of VMs to exclude from backup, comma seperated.
 v, vhdinclude        List of VHDs file names to backup, comma separated.
 i, vhdignore         List of VHDs file names to ignore, comma separated.
 a, all               (Default: True) Is set, backup all VMs on this server.


### PR DESCRIPTION
I needed the exclude option when using the backup all option.  I have a couple of VM templates that I keep mounted, but don't want to keep backing them up all of the time.

I tested using -a with and without the -x option.  Works for me, might be useful for others.